### PR TITLE
feat: support lazy S3 streaming

### DIFF
--- a/nc_stream/cli.py
+++ b/nc_stream/cli.py
@@ -8,7 +8,7 @@ def main():
     parser.add_argument("--group", default="/PRODUCT")
     args = parser.parse_args()
 
-    ds = stream_netcdf(args.bucket, args.key, args.group)
+    ds = stream_netcdf(args.bucket, args.key, group=args.group)
     print(ds)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support engine/group/storage options and chunks in stream_netcdf
- stream NetCDF lazily from S3 via fsspec
- accept .nc, .nc4, or .cdf keys and update CLI usage

## Testing
- `python -m pip install fsspec s3fs` *(fails: Could not find a version that satisfies the requirement fsspec)*
- `pytest -q` *(fails: No module named 'fsspec')*

------
https://chatgpt.com/codex/tasks/task_e_68af003185a4833288476b4440e70fc6