### PR TITLE
feat: enhance CLI arguments

### DIFF
--- a/nc_stream/cli.py
+++ b/nc_stream/cli.py
@@ -1,15 +1,40 @@
 import argparse
 from . import stream_netcdf
 
+
 def main():
-    parser = argparse.ArgumentParser(description="Stream Sentinel-5P NetCDF from S3")
+    parser = argparse.ArgumentParser(description="Stream NetCDF from S3")
     parser.add_argument("--bucket", required=True)
     parser.add_argument("--key", required=True)
-    parser.add_argument("--group", default="/PRODUCT")
+    parser.add_argument("--group", default=None)
+    parser.add_argument("--engine")
+    parser.add_argument(
+        "--storage-option",
+        action="append",
+        default=[],
+        metavar="key=value",
+        help="Storage option for the stream (can repeat)",
+    )
     args = parser.parse_args()
 
-    ds = stream_netcdf(args.bucket, args.key, args.group)
+    storage_options = {}
+    for item in args.storage_option:
+        if "=" not in item:
+            parser.error("--storage-option must be in key=value format")
+        key, value = item.split("=", 1)
+        storage_options[key] = value
+
+    call_args = {"bucket": args.bucket, "key": args.key}
+    if args.group is not None:
+        call_args["group"] = args.group
+    if args.engine is not None:
+        call_args["engine"] = args.engine
+    if storage_options:
+        call_args["storage_options"] = storage_options
+
+    ds = stream_netcdf(**call_args)
     print(ds)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- extend CLI: optional group and engine flags, repeated storage options
- accept engine and storage options in `stream_netcdf`

## Testing
- `PYTHONPATH=. pytest -k 'not integration' -q`


------
https://chatgpt.com/codex/tasks/task_e_68af00771b688332803db75f46669f5a