### PR TITLE
feat: support flexible netcdf parameters and add S3-mocked tests

### DIFF
--- a/nc_stream/stream.py
+++ b/nc_stream/stream.py
@@ -1,24 +1,36 @@
 from __future__ import annotations
+
 import io
-from typing import Optional
+from typing import Any, Optional
 
 import boto3
 import xarray as xr
 from botocore import UNSIGNED, exceptions as boto_exc
 from botocore.config import Config
 
-def stream_netcdf(bucket: str, key: str, group: str = "/PRODUCT") -> xr.Dataset:
-    """
-    Stream a NetCDF file from a *public* S3 bucket and return an xarray.Dataset.
+
+def stream_netcdf(
+    bucket: str,
+    key: str,
+    *,
+    group: Optional[str] = None,
+    engine: Optional[str] = None,
+    chunks: Any | None = None,
+) -> xr.Dataset:
+    """Stream a NetCDF file from a *public* S3 bucket and return an ``xarray.Dataset``.
 
     Parameters
     ----------
     bucket : str
         S3 bucket name (e.g., "meeo-s5p").
     key : str
-        Object key path to the .nc file within the bucket.
-    group : str, default "/PRODUCT"
-        HDF5/NetCDF group to open.
+        Object key path to the NetCDF file within the bucket.
+    group : str, optional
+        HDF5/NetCDF group to open. ``None`` opens the root group.
+    engine : str, optional
+        Backend engine passed to :func:`xarray.open_dataset`.
+    chunks : Any, optional
+        Chunking argument forwarded to :func:`xarray.open_dataset`.
 
     Returns
     -------
@@ -51,13 +63,12 @@ def stream_netcdf(bucket: str, key: str, group: str = "/PRODUCT") -> xr.Dataset:
         raise RuntimeError(f"S3 access failed for s3://{bucket}/{key}: {e}") from e
 
     try:
-        # Read into memory; do NOT write to disk
         body = obj["Body"].read()
         buffer = io.BytesIO(body)
         buffer.seek(0)
-        # Important: specify engine and group
-        ds = xr.open_dataset(buffer, engine="h5netcdf", group=group)
-        # Eagerly load metadata/coords so underlying stream can GC safely
+        ds = xr.open_dataset(buffer, engine=engine, group=group, chunks=chunks)
         return ds
     except Exception as e:
-        raise RuntimeError(f"Failed to open NetCDF (group='{group}'): {e}") from e
+        raise RuntimeError(
+            f"Failed to open NetCDF (group='{group}', engine='{engine}'): {e}"
+        ) from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests requiring network access",
+]

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,26 +1,89 @@
-import os
+import io
+import socket
+
+import boto3
 import pytest
 import xarray as xr
+from botocore.response import StreamingBody
+from botocore.stub import Stubber
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from nc_stream.stream import stream_netcdf
 
+
+@pytest.fixture
+def s3_netcdf(monkeypatch):
+    ds = xr.Dataset({"data": ("x", [1, 2, 3])})
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".nc") as tmp:
+        ds.to_netcdf(tmp.name, engine="h5netcdf")
+        tmp.seek(0)
+        data = tmp.read()
+
+    client = boto3.client("s3", region_name="us-east-1")
+    stubber = Stubber(client)
+    response = {"Body": StreamingBody(io.BytesIO(data), len(data))}
+    params = {"Bucket": "test-bucket", "Key": "test.nc"}
+    stubber.add_response("get_object", response, params)
+    stubber.activate()
+    monkeypatch.setattr(boto3, "client", lambda *a, **k: client)
+
+    yield ds, "test-bucket", "test.nc"
+
+    stubber.deactivate()
+
+
+def test_open_without_group_or_engine(s3_netcdf):
+    expected, bucket, key = s3_netcdf
+    ds = stream_netcdf(bucket, key)
+    xr.testing.assert_identical(ds, expected)
+
+
+def test_custom_engine_group_chunks(s3_netcdf):
+    pytest.importorskip("dask.array")
+    _, bucket, key = s3_netcdf
+    ds = stream_netcdf(bucket, key, engine="h5netcdf", group=None, chunks={"x": 1})
+    assert ds["data"].data.chunks[0][0] == 1
+
+
+def test_unsupported_extension():
+    with pytest.raises(ValueError):
+        stream_netcdf("bucket", "file.txt")
+
+
+def _has_network() -> bool:
+    try:
+        socket.create_connection(("example.com", 80), timeout=1)
+        return True
+    except OSError:
+        return False
+
+
 @pytest.mark.integration
+@pytest.mark.skipif(not _has_network(), reason="requires network access")
 def test_stream_netcdf_integration():
     bucket = "meeo-s5p"
-    key = "NRTI/L2__CO____/2023/08/01/S5P_NRTI_L2__CO_____20230801T230402_20230801T230902_30057_03_020500_20230802T000504.nc"
+    key = (
+        "NRTI/L2__CO____/2023/08/01/"
+        "S5P_NRTI_L2__CO_____20230801T230402_20230801T230902_30057_03_020500_20230802T000504.nc"
+    )
 
-    ds = stream_netcdf(bucket, key)
+    ds = stream_netcdf(bucket, key, engine="h5netcdf", group="/PRODUCT")
     assert isinstance(ds, xr.Dataset)
-    # Keep assertions resilient across minor product changes
     assert len(ds.data_vars) > 0
     assert len(ds.coords) >= 1
     assert "latitude" in ds
     assert "longitude" in ds
     assert "carbonmonoxide_total_column" in ds
 
-def test_stream_netcdf_param_validation():
+
+def test_param_validation():
     with pytest.raises(ValueError):
         stream_netcdf("", "file.nc")
     with pytest.raises(ValueError):
         stream_netcdf("bucket", "")
-    with pytest.raises(ValueError):
-        stream_netcdf("bucket", "not_netcdf.txt")


### PR DESCRIPTION
## Summary
- allow `stream_netcdf` to accept custom engine, group and chunk arguments
- add unit tests using an in-memory NetCDF file and S3 stub
- mark integration test to run only when network is available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af00825ea8833299cb83281ff0b164