### PR TITLE
Expand CLI options for NetCDF streaming

### DIFF
--- a/nc_stream/cli.py
+++ b/nc_stream/cli.py
@@ -1,14 +1,33 @@
 import argparse
+import json
 from . import stream_netcdf
 
+
 def main():
-    parser = argparse.ArgumentParser(description="Stream Sentinel-5P NetCDF from S3")
+    parser = argparse.ArgumentParser(description="Stream NetCDF from S3")
     parser.add_argument("--bucket", required=True)
     parser.add_argument("--key", required=True)
-    parser.add_argument("--group", default="/PRODUCT")
+    parser.add_argument("--group", default=None)
+    parser.add_argument("--engine", default=None)
+    parser.add_argument("--chunks", default=None)
+    parser.add_argument(
+        "--storage-option", action="append", default=[], metavar="key=value"
+    )
     args = parser.parse_args()
 
-    ds = stream_netcdf(args.bucket, args.key, group=args.group)
+    kwargs = vars(args).copy()
+    storage_list = kwargs.pop("storage_option", [])
+    storage_options = {}
+    for item in storage_list:
+        if "=" in item:
+            key, value = item.split("=", 1)
+            storage_options[key] = value
+    chunks = kwargs.get("chunks")
+    if chunks is not None:
+        kwargs["chunks"] = json.loads(chunks)
+    kwargs["storage_options"] = storage_options
+
+    ds = stream_netcdf(**kwargs)
     print(ds)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Simplify CLI description for streaming NetCDF files from S3
- Add optional engine, group, chunking, and repeated storage-option flags
- Forward parsed arguments to `stream_netcdf` and display resulting dataset

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fsspec')*
- `pip install fsspec` *(fails: Could not find a version that satisfies the requirement due to proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68af079f882c83328e0dd0c76d59b9d5