### PR TITLE
docs: update Sentinel-5P example with QA filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,34 @@ print(ds)
 
 ### Example: Sentinel-5P NRTI CO dataset
 
-The library can stream any public NetCDF file. One possible dataset is the Sentinel-5P Near Real Time CO product hosted on AWS.
+This example streams a Sentinel-5P Near Real Time CO product hosted on AWS. It requires `numpy` and `xarray` and filters out pixels with a low quality assurance (QA) score.
 
 ```python
+import numpy as np
+import xarray as xr
 from nc_stream import stream_netcdf
 
-bucket = "meeo-s5p"
-key = "NRTI/L2__CO____/2023/08/01/S5P_NRTI_L2__CO_____20230801T230402_20230801T230902_30057_03_020500_20230802T000504.nc"
-#group = "/PRODUCT"
-#engine="h5netcdf"
+def fetch_filtered_co():
+    bucket = "meeo-s5p"
+    key = "NRTI/L2__CO____/2023/08/01/S5P_NRTI_L2__CO_____20230801T230402_20230801T230902_30057_03_020500_20230802T000504.nc"
 
-ds = stream_netcdf(bucket, key)
-print(ds)
+    ds = stream_netcdf(
+        bucket,
+        key,
+        group="/PRODUCT",
+        engine="h5netcdf",
+        storage_options={"anon": True},
+    )
+
+    co = ds["carbonmonoxide_total_column"]
+    qa = ds["qa_value"]
+
+    filtered = co.where(qa > 0.5)
+    print(filtered.values)
+    return filtered.values
 ```
+
+The QA threshold of `0.5` discards retrievals flagged as low quality, retaining only the more reliable measurements.
 # Acknowledgements
 Thanks to the [AWS Open Data initiative](https://registry.opendata.aws/) and the open-source community behind `xarray`, `fsspec`, and `s3fs`.
 


### PR DESCRIPTION
## Summary
- replace Sentinel-5P README example with function using `group="/PRODUCT"`, `engine="h5netcdf"`, and `storage_options={"anon": True}`
- demonstrate filtering `carbonmonoxide_total_column` values where `qa_value > 0.5`

## Testing
- `PYTHONPATH=. pytest` *(skipped: fsspec)*

------
https://chatgpt.com/codex/tasks/task_e_68b06c6b4040833294f435e1c1614efd